### PR TITLE
src: add ce response decorator

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,3 +1,5 @@
+const Spec = require('../lib/ce-constants.js').Spec;
+
 class Context {
   constructor(request) {
     this.__ow_user = '';
@@ -8,6 +10,46 @@ class Context {
     this.__ow_body = JSON.stringify(request.body);
     Object.assign(this, request.query);
     this.log = request.log;
+  }
+
+  cloudEventResponse(response) {
+    return new CloudEventResponse(response);
+  }
+
+}
+
+class CloudEventResponse {
+  #response;  // eslint-disable-line
+
+  constructor(response) {
+    this.#response = response;
+    if (!this.#response.headers) {
+      this.#response.headers = [];
+    }
+  }
+
+  version(version) {
+    this.#response.headers[Spec.version] = version;
+    return this;
+  }
+
+  id(id) {
+    this.#response.headers[Spec.id] = id;
+    return this;
+  }
+
+  type(type) {
+    this.#response.headers[Spec.type] = type;
+    return this;
+  }
+
+  source(source) {
+    this.#response.headers[Spec.source] = source;
+    return this;
+  }
+
+  response() {
+    return this.#response;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "supertest": "^4.0.2",
     "tap-spec": "^5.0.0",
     "tape": "^4.11.0"
-  }
+  },
+  "standardx": {
+    "ignore": [
+      "lib/context.js"
+    ]
+ }
 }

--- a/test/fixtures/cloud-event/with-response.js
+++ b/test/fixtures/cloud-event/with-response.js
@@ -1,0 +1,15 @@
+module.exports = function testFunc(context) {
+  if (context.cloudevent) {
+    const response = {
+      message: context.cloudevent.data.message
+    };
+    return context.cloudEventResponse(response).version('0.3')
+                                               .id('dummyid')
+                                               .type('dev.ocf.js.type')
+                                               .source('dev/ocf/js/service')
+                                               .response();
+  }
+  else {
+    return new Error('No cloud event received');
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -121,6 +121,31 @@ test('Responds to 0.3 binary cloud events', t => {
   }, { log: false });
 });
 
+test('Responds with 0.3 binary cloud event', t => {
+  const func = require(`${__dirname}/fixtures/cloud-event/with-response.js`);
+  framework(func, server => {
+    request(server)
+      .post('/')
+      .send({ message: 'hello' })
+      .set(Spec.id, '1')
+      .set(Spec.source, 'integration-test')
+      .set(Spec.type, 'dev.knative.example')
+      .set(Spec.version, '0.3')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end((err, res) => {
+        t.error(err, 'No error');
+        t.equal(res.body.message, 'hello');
+        t.equal(res.headers[Spec.type], 'dev.ocf.js.type');
+        t.equal(res.headers[Spec.source], 'dev/ocf/js/service');
+        t.equal(res.headers[Spec.id], 'dummyid');
+        t.equal(res.headers[Spec.version], '0.3');
+        t.end();
+        server.close();
+      });
+  }, { log: false });
+});
+
 test('Responds to 1.0 binary cloud events', t => {
   const func = require(`${__dirname}/fixtures/cloud-event/`);
   framework(func, server => {


### PR DESCRIPTION
This commit adds a method to the Context class that is intended to be
used by services that which to respond with a cloud event message. The
function will decorate a Response setting headers using functions
saving users from having to find and set the correct headers.