### PR TITLE
lib(deps): update to cloudevents 3.0.x

### DIFF
--- a/lib/ce-constants.js
+++ b/lib/ce-constants.js
@@ -1,10 +1,10 @@
-const { Constants } = require('cloudevents-sdk');
+const Constants = require('cloudevents/dist/constants').default;
 
 const Spec = {
-  version: Constants.BINARY_HEADERS_1.SPEC_VERSION,
-  type: Constants.BINARY_HEADERS_1.TYPE,
-  id: Constants.BINARY_HEADERS_1.ID,
-  source: Constants.BINARY_HEADERS_1.SOURCE,
+  version: Constants.CE_HEADERS.SPEC_VERSION,
+  type: Constants.CE_HEADERS.TYPE,
+  id: Constants.CE_HEADERS.ID,
+  source: Constants.CE_HEADERS.SOURCE,
   ceJsonContentType: Constants.MIME_CE_JSON
 };
 

--- a/lib/event-handler.js
+++ b/lib/event-handler.js
@@ -1,7 +1,5 @@
-const { HTTPReceiver } = require('cloudevents-sdk');
+const { Receiver } = require('cloudevents');
 const Spec = require('./ce-constants.js').Spec;
-
-const receiver = new HTTPReceiver();
 
 function use(fastify, opts, done) {
   fastify.addContentTypeParser('application/cloudevents+json',
@@ -16,10 +14,10 @@ function use(fastify, opts, done) {
   fastify.addHook('preHandler', function(request, reply, done) {
     if (request.isCloudEvent()) {
       try {
-        const event = receiver.accept(request.headers, request.body);
-        request.context.cloudevent = event.format();
+        const event = Receiver.accept(request.headers, request.body);
+        request.context.cloudevent = event;
       } catch (err) {
-        if (err.message === 'invalid spec version') {
+        if (err.message.startsWith('invalid spec version')) {
           reply.code(406);
         }
         done(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,14 +537,14 @@
         "wrap-ansi": "^5.1.0"
       }
     },
-    "cloudevents-sdk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/cloudevents-sdk/-/cloudevents-sdk-2.0.2.tgz",
-      "integrity": "sha512-sXTYWUFbUYg75b+71MH7AhHsEC4iCdlxf4W9flveRbih6xSDOuLryWbCuBZpeO1iLrt5uT1gD1flB38RhVSVBQ==",
+    "cloudevents": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.0.1.tgz",
+      "integrity": "sha512-WcuOuFl0iB3XfPFjAVFtdV90JCBVlgsDtZ6Sop6C9iE3SDloXJGdPx/6QcIG1284PB+C70MxkIgtUP3BAxzd4g==",
       "requires": {
-        "ajv": "~6.12.0",
+        "ajv": "~6.12.3",
         "axios": "~0.19.2",
-        "uuid": "~8.0.0"
+        "uuid": "~8.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -564,9 +564,9 @@
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "uuid": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
         }
       }
     },
@@ -2616,9 +2616,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -3669,9 +3669,9 @@
       "dev": true
     },
     "standard-version": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.1.tgz",
-      "integrity": "sha512-FLZdjvL2tBdwlctfQeyBf4+dX+SFljwdWfUA0F3wPiU9Rn0+FSuD3I0WXuzC1RmcaWwU5WL3EyV4Aanejc8Pqg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.2.tgz",
+      "integrity": "sha512-L8X9KFq2SmVmaeZgUmWHFJMOsEWpjgFAwqic6yIIoveM1kdw1vH4Io03WWxUDjypjGqGU6qUtcJoR8UvOv5w3g==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lib"
   ],
   "dependencies": {
-    "cloudevents-sdk": "^2.0.1",
+    "cloudevents": "^3.0.1",
     "fastify": "^2.10.0",
     "overload-protection": "^1.1.0",
     "qs": "^6.9.0"

--- a/test/test.js
+++ b/test/test.js
@@ -180,7 +180,6 @@ test('Responds with error code (4xx or 5xx) to malformed cloud events', t => {
       .send({ message: 'hello' })
       .set(Spec.id, '1')
       .set(Spec.source, 'integration-test')
-      .set(Spec.type, 'dev.knative.example')
       .set(Spec.version, '0.3')
       .set('ce-datacontenttype', 'application/json')
       .expect('Content-Type', /json/)
@@ -207,7 +206,7 @@ test('Responds with 406 Not Acceptable to unknown cloud event versions', t => {
       .end((err, res) => {
         t.error(err, 'No error');
         t.equal(res.body.statusCode, 406);
-        t.equal(res.body.message, 'invalid spec version');
+        t.equal(res.body.message, 'invalid spec version 11.0');
         t.end();
         server.close();
       });


### PR DESCRIPTION
This commit updates the cloudevent-sdk to use the newly named cloudevents
module at version 3.0.1.