### PR TITLE
deps: bump to fastify 3.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ function start(func, port, cb, options) {
   const server = fastify({ logger: log });
 
   // All incoming requests get a Context object
-  server.decorateRequest('context');
+  server.decorateRequest('fcontext');
   server.addHook('preHandler', (req, reply, done) => {
-    req.context = new Context(req, reply);
+    req.fcontext = new Context(req, reply);
     done();
   });
 

--- a/lib/event-handler.js
+++ b/lib/event-handler.js
@@ -15,7 +15,7 @@ function use(fastify, opts, done) {
     if (request.isCloudEvent()) {
       try {
         const event = Receiver.accept(request.headers, request.body);
-        request.context.cloudevent = event;
+        request.fcontext.cloudevent = event;
       } catch (err) {
         if (err.message.startsWith('invalid spec version')) {
           reply.code(406);

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -11,12 +11,11 @@ module.exports = function(fastify, opts, done) {
   fastify.post('/', doPost);
 
   async function doGet(request, reply) {
-    sendReply(reply, await invokeFunction(request.context, reply.log));
+    sendReply(reply, await invokeFunction(request.fcontext, reply.log));
   }
 
   async function doPost(request, reply) {
-    // request.context.body = request.body;
-    sendReply(reply, await invokeFunction(request.context, reply.log));
+    sendReply(reply, await invokeFunction(request.fcontext, reply.log));
   }
 
   eventHandler(fastify, null, done);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,9 +1475,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1509,9 +1509,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.2.0.tgz",
-      "integrity": "sha512-+4gv8GiiblMtJf1z/sCQfEbndugmlpQu8wx4IgEpAstKY36fHIMBCSny9Wz6fHfq+FU/FTpYbrCFxzCMwiykFQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.3.0.tgz",
+      "integrity": "sha512-dAlGT7MoekQ2w5nmoxq1zFL+vFPcgRNBtMaopQIITLeUwesvfso4bX0bXwYO3vPFLoKgGc/p8GwSDyq6t5O3nA==",
       "requires": {
         "abstract-logging": "^2.0.0",
         "ajv": "^6.12.2",
@@ -1531,9 +1531,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1596,11 +1596,11 @@
       }
     },
     "find-my-way": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.1.tgz",
-      "integrity": "sha512-tHUHIRGTcfl3phGKLZeD2Xkb+I0QZr4xduSwCJG5Ke11pdJTGuMDtAyAiJzUdWBZJgHA0H42Pb0WF3H321KbRA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.4.tgz",
+      "integrity": "sha512-Trl/mNAVvTgCpo9ox6yixkwiZUvecKYUQZoAuMCBACsgGqv+FbWe+jE5sBA5+U8LIWrJk/cw8zPV53GPrjTnsw==",
       "requires": {
-        "fast-decode-uri-component": "^1.0.0",
+        "fast-decode-uri-component": "^1.0.1",
         "safe-regex2": "^2.0.0",
         "semver-store": "^0.3.0"
       }
@@ -2659,9 +2659,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -3313,22 +3313,22 @@
       }
     },
     "pino": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.0.tgz",
-      "integrity": "sha512-qDIFPZ2h2AMrp+JIWKFUtejiTv5F/+glbizrG9VNvegSCSK6sqnRmerNM9R98/x3RxwKkIf5kJ9q4chXdBdvJA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
+      "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
         "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.0"
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg=="
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -3652,9 +3652,9 @@
       }
     },
     "sonic-boom": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.2.tgz",
-      "integrity": "sha512-sRMmXu7uFDXoniGvtLHuQk5KWovLWoi6WKASn7rw0ro41mPf0fOolkGp4NE6680CbxvNh26zWNyFQYYWXe33EA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "cloudevents": "^3.1.0",
-    "fastify": "^3.2.0",
+    "fastify": "^3.3.0",
     "overload-protection": "^1.1.0",
     "qs": "^6.9.0"
   },


### PR DESCRIPTION
Changes in 3.2.1 to fastify resulted in a broken framework. The fastify
module added a `context` property to the request object, which we had
been decorating with a property by the same name. This commit bumps to
the latest 3.3.0 of fastify, and changes the property that we decorate
the request object with to `fcontext`. These changes are entirely
internal and do not affect the user function.