### PR TITLE
feat: change module name to faas-js-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ still to be determined.
 In my current working directory, I have an `index.js` file like this.
 
 ```js
-const framework = require('@redhat/faas-js-runtime');
+const framework = require('faas-js-runtime');
 
 // My function directory is in ./function-dir
 framework(require(`${__dirname}/function-dir/`), server => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@redhat/faas-js-runtime",
+  "name": "faas-js-runtime",
   "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@redhat/faas-js-runtime",
+  "name": "faas-js-runtime",
   "version": "0.2.3",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit removes the `@redhat` prefix from the module name, since the prefix should be reserved for productized modules.

Note that this is a BREAKING CHANGE