### PR TITLE
fix: remove openwhisk varaiables from context

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -12,13 +12,6 @@ class Context {
 
     Object.assign(this, request.query);
     this.log = request.log;
-
-    this.__ow_user = '';
-    this.__ow_method = request.raw.method;
-    this.__ow_headers = request.headers;
-    this.__ow_path = '';
-    this.__ow_query = request.query;
-    this.__ow_body = JSON.stringify(request.body);
   }
 
   cloudEventResponse(response) {

--- a/test/test.js
+++ b/test/test.js
@@ -338,28 +338,6 @@ test('Accepts x-www-form-urlencoded content via HTTP post', t => {
   }, { log: false });
 });
 
-test('Exposes OpenWhisk compatible context properties', t => {
-  const func = require(`${__dirname}/fixtures/openwhisk-properties/`);
-  framework(func, server => {
-    t.plan(7);
-    request(server)
-      .get('/?lunch=tacos')
-      .expect(200)
-      .expect('Content-type', /json/)
-      .end((err, res) => {
-        t.error(err, 'No error');
-        t.equal(res.body.__ow_user, '');
-        t.equal(res.body.__ow_method, 'GET');
-        t.equal(typeof res.body.__ow_headers, 'object');
-        t.equal(res.body.__ow_path, '');
-        t.equal(typeof res.body.__ow_query, 'object');
-        t.equal(res.body.__ow_body, 'null');
-        t.end();
-        server.close();
-      });
-    }, { log: false });
-});
-
 test('Exposes readiness URL', t => {
   framework(_ => { }, server => {
     t.plan(2);


### PR DESCRIPTION
This commit removes the openwhisk variables that were added to the context object early in this project's life, when we were not sure if we would support running in openwhisk.

Signed-off-by: Lance Ball <lball@redhat.com>