### PR TITLE
chore(actions): add id to release-please action

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2.4.1
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
The ID is used later in the action to determine if a release was actually created.
Since it wasn't set, an automated release did not occur for 0.3.0. This fixes that.

