### PR TITLE
feat: provide cloudevent data if it exists as first parameter to function

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -15,7 +15,11 @@ module.exports = function invoker(func) {
     };
 
     try {
-      payload.response = await func(context);
+      let data;
+      if (context.cloudevent && context.cloudevent.data) {
+        data = context.cloudevent.data;
+      }
+      payload.response = await func(context, data);
     } catch (err) {
       log.error(err);
       payload.response = {

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -15,11 +15,15 @@ module.exports = function invoker(func) {
     };
 
     try {
-      let data;
       if (context.cloudevent && context.cloudevent.data) {
-        data = context.cloudevent.data;
+        // If there is a cloud event, provide the data
+        // as the first parameter
+        payload.response = await func(context.cloudevent.data, context);
+      } else {
+        // Invoke with context
+        // TODO: Should this actually just get the Node.js request object?
+        payload.response = await func(context);
       }
-      payload.response = await func(context, data);
     } catch (err) {
       log.error(err);
       payload.response = {

--- a/test/fixtures/cloud-event/index.js
+++ b/test/fixtures/cloud-event/index.js
@@ -1,4 +1,4 @@
-module.exports = function testFunc(context) {
-  if (context.cloudevent) return { message: context.cloudevent.data.message };
+module.exports = function testFunc(data, context) {
+  if (context.cloudevent) return { message: data.message };
   else return new Error('No cloud event received');
 };

--- a/test/fixtures/cloud-event/with-response.js
+++ b/test/fixtures/cloud-event/with-response.js
@@ -1,7 +1,7 @@
-module.exports = function testFunc(context) {
+module.exports = function testFunc(data, context) {
   if (context.cloudevent) {
     const response = {
-      message: context.cloudevent.data.message
+      message: data.message
     };
     return context.cloudEventResponse(response).version('0.3')
                                                .id('dummyid')

--- a/test/test.js
+++ b/test/test.js
@@ -172,7 +172,7 @@ test('Responds to 1.0 structured cloud events', t => {
   }, { log: false });
 });
 
-test('Extracts event data as second parameter to function', t => {
+test('Extracts event data as the first parameter to a function', t => {
   const data = {
     lunch: "tacos"
   };

--- a/test/test.js
+++ b/test/test.js
@@ -177,9 +177,9 @@ test('Extracts event data as second parameter to function', t => {
     lunch: "tacos"
   };
 
-  framework((context, eventData) => {
-    t.deepEqual(eventData, data);
-    return data;
+  framework(menu => {
+    t.equal(menu.lunch, data.lunch);
+    return menu;
   }, server => {
     request(server)
       .post('/')

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,36 @@ test('Responds to 1.0 structured cloud events', t => {
   }, { log: false });
 });
 
+test('Extracts event data as second parameter to function', t => {
+  const data = {
+    lunch: "tacos"
+  };
+
+  framework((context, eventData) => {
+    t.deepEqual(eventData, data);
+    return data;
+  }, server => {
+    request(server)
+      .post('/')
+      .send({
+        id: '1',
+        source: 'http://integration-test',
+        type: 'com.redhat.faas.test',
+        specversion: '1.0',
+        data
+      })
+      .set('Content-type', 'application/cloudevents+json; charset=utf-8')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .end((err, res) => {
+        t.error(err, 'No error');
+        t.deepEqual(res.body, data);
+        t.end();
+        server.close();
+      });
+  }, { log: false });
+});
+
 test('Responds with error code (4xx or 5xx) to malformed cloud events', t => {
   const func = require(`${__dirname}/fixtures/cloud-event/`);
   framework(func, server => {


### PR DESCRIPTION
If a CloudEvent is the incoming HTTP request, and if the data attribute
has been set, provide it as the second parameter to the function invocation.
This makes the module work a bit more like funqy, but we still expose
a context object.

Signed-off-by: Lance Ball <lball@redhat.com>