### PR TITLE
fix: handle cloudevents that have no data

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -15,7 +15,7 @@ module.exports = function invoker(func) {
     };
 
     try {
-      if (context.cloudevent && context.cloudevent.data) {
+      if (context.cloudevent) {
         // If there is a cloud event, provide the data
         // as the first parameter
         payload.response = await func(context.cloudevent.data, context);


### PR DESCRIPTION
This commit ensures that a CloudEvent function is correctly invoked when an event with no data is received.

/cc @slinkydeveloper 

Fixes: https://github.com/boson-project/faas-js-runtime/issues/66

Signed-off-by: Lance Ball <lball@redhat.com>