### PR TITLE
feat: handle CloudEvent and Message responses from function invocation

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,4 @@
-const Spec = require('../lib/ce-constants.js').Spec;
+const { CloudEvent } = require('cloudevents');
 
 class Context {
   constructor(request) {
@@ -24,34 +24,31 @@ class CloudEventResponse {
   #response;
 
   constructor(response) {
-    this.#response = response;
-    if (!this.#response.headers) {
-      this.#response.headers = [];
-    }
+    this.#response = { data: response };
   }
 
   version(version) {
-    this.#response.headers[Spec.version] = version;
+    this.#response.specversion = version;
     return this;
   }
 
   id(id) {
-    this.#response.headers[Spec.id] = id;
+    this.#response.id = id;
     return this;
   }
 
   type(type) {
-    this.#response.headers[Spec.type] = type;
+    this.#response.type = type;
     return this;
   }
 
   source(source) {
-    this.#response.headers[Spec.source] = source;
+    this.#response.source = source;
     return this;
   }
 
   response() {
-    return this.#response;
+    return new CloudEvent(this.#response);
   }
 }
 

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -26,11 +26,7 @@ module.exports = function invoker(func) {
         payload.response = await func(context);
       }
     } catch (err) {
-      log.error(err);
-      payload.response = {
-        statusCode: err.code ? err.code : 500,
-        statusMessage: err.message
-      };
+      payload.response = handleError(err, log);
     }
 
     // Return 204 No Content if the function returns
@@ -38,12 +34,6 @@ module.exports = function invoker(func) {
     if (!payload.response) {
       payload.code = 204;
       return payload;
-    }
-
-    // Check for user defined status code
-    if (payload.response.statusCode) {
-      payload.code = payload.response.statusCode;
-      delete payload.response.statusCode;
     }
 
     // Check for user defined headers
@@ -64,9 +54,16 @@ module.exports = function invoker(func) {
         const message = HTTP.binary(payload.response);
         payload.headers = {...payload.headers, ...message.headers};
         payload.response = message.body;  
-      } catch (e) {
-        console.error(e);
+      } catch (err) {
+        payload.response = handleError(err, log);
+        return payload;
       }
+    }
+
+    // Check for user defined status code
+    if (payload.response.statusCode) {
+      payload.code = payload.response.statusCode;
+      delete payload.response.statusCode;
     }
 
     // Check for user supplied body
@@ -77,3 +74,11 @@ module.exports = function invoker(func) {
     return payload;
   };
 };
+
+function handleError(err, log) {
+  log.error(err);
+  return {
+    statusCode: err.code ? err.code : 500,
+    statusMessage: err.message
+  };
+}

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -1,4 +1,5 @@
 'use strict';
+const { CloudEvent, HTTP } = require('cloudevents');
 
 module.exports = function invoker(func) {
   return async function invokeFunction(context, log) {
@@ -7,10 +8,10 @@ module.exports = function invoker(func) {
       code: 200,
       response: undefined,
       headers: {
-        'Content-Type': 'application/json; charset=utf8',
-        'Access-Control-Allow-Methods':
+        'content-type': 'application/json; charset=utf8',
+        'access-control-allow-methods':
           'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH',
-        'Access-Control-Allow-Origin': '*'
+        'access-control-allow-origin': '*'
       }
     };
 
@@ -47,8 +48,31 @@ module.exports = function invoker(func) {
 
     // Check for user defined headers
     if (typeof payload.response.headers === 'object') {
-      Object.assign(payload.headers, payload.response.headers);
+      const headers = {};
+      // normalize the headers as lowercase
+      for (const header in payload.response.headers) {
+        headers[header.toLocaleLowerCase()] = payload.response.headers[header];
+      }
+      payload.headers = { ...payload.headers, ...headers };
       delete payload.response.headers;
+    }
+
+    // If the response is a CloudEvent, we need to convert it
+    // to a Message first and respond with the headers/body
+    if (payload.response instanceof CloudEvent) {
+      try {
+        const message = HTTP.binary(payload.response);
+        payload.headers = {...payload.headers, ...message.headers};
+        payload.response = message.body;  
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    // Check for user supplied body
+    if (payload.response.body !== undefined) {
+      payload.response = payload.response.body;
+      delete payload.response.body;
     }
     return payload;
   };

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -22,7 +22,8 @@ module.exports = function(fastify, opts, done) {
 };
 
 function sendReply(reply, payload) {
-  if (payload.headers['Content-Type'].startsWith('text/plain')) {
+  const contentType = payload.headers['content-type'];
+  if (contentType.startsWith('text/plain') && (typeof payload.response !== 'string')) {
     payload.response = JSON.stringify(payload.response);
   }
   return reply

--- a/package-lock.json
+++ b/package-lock.json
@@ -547,19 +547,19 @@
       }
     },
     "cloudevents": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.1.0.tgz",
-      "integrity": "sha512-98t6+Qs/r2PiYflNFztUcPSDfaaRU8KKMzaMR4dn9MPpijZj3A1W+L307t00D6xRzXdkDDiMcB2THS3dCp+kcw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.2.0.tgz",
+      "integrity": "sha512-D5QVEJtREXxM0QGmla0FKs0cctcIUQIAJpIEYx7R11PFFh9O7Bykos/gZCYJgzTieDrnEesJ+6pD03P48ZRrGw==",
       "requires": {
         "ajv": "~6.12.3",
         "axios": "~0.19.2",
-        "uuid": "~8.2.0"
+        "uuid": "~8.3.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -573,9 +573,9 @@
           "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": "./bin/cli.js",
   "dependencies": {
     "chalk": "^4.1.0",
-    "cloudevents": "^3.1.0",
+    "cloudevents": "^3.2.0",
     "commander": "^6.1.0",
     "death": "^1.1.0",
     "fastify": "^3.3.0",

--- a/test/fixtures/query-params/index.js
+++ b/test/fixtures/query-params/index.js
@@ -1,3 +1,3 @@
 module.exports = function testFunc(context) {
-  return context;
+  return { ...context.query };
 };

--- a/test/test-context.js
+++ b/test/test-context.js
@@ -43,8 +43,8 @@ test('Provides HTTP request query parameters with the context parameter', t => {
       .expect('Content-Type', /json/)
       .end((err, res) => {
         t.error(err, 'No error');
-        t.equal(res.body.query.lunch, 'tacos');
-        t.equal(res.body.query.supper, 'burgers');
+        t.equal(res.body.lunch, 'tacos');
+        t.equal(res.body.supper, 'burgers');
         t.end();
         server.close();
       });


### PR DESCRIPTION
We already **kind of** handled them, but these changes make it more intuitive
for the user. For example, the function author can respond with `new CloudEvent(...)`
or `HTTP.binary(event)` and the framework should handle the response correctly.

This partially fixes https://github.com/boson-project/functions/issues/15

Signed-off-by: Lance Ball <lball@redhat.com>