### PR TITLE
fix: reverse the parameter order when invoking

### DIFF
--- a/lib/event-handler.js
+++ b/lib/event-handler.js
@@ -1,4 +1,4 @@
-const { Receiver } = require('cloudevents');
+const { HTTP } = require('cloudevents');
 const Spec = require('./ce-constants.js').Spec;
 
 function use(fastify, opts, done) {
@@ -14,8 +14,10 @@ function use(fastify, opts, done) {
   fastify.addHook('preHandler', function(request, reply, done) {
     if (request.isCloudEvent()) {
       try {
-        const event = Receiver.accept(request.headers, request.body);
-        request.fcontext.cloudevent = event;
+        request.fcontext.cloudevent = HTTP.toEvent({
+          headers: request.headers, 
+          body: request.body
+        });
       } catch (err) {
         if (err.message.startsWith('invalid spec version')) {
           reply.code(406);

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -19,7 +19,7 @@ module.exports = function invoker(func) {
       if (context.cloudevent) {
         // If there is a cloud event, provide the data
         // as the first parameter
-        payload.response = await func(context.cloudevent.data, context);
+        payload.response = await func(context, context.cloudevent.data);
       } else {
         // Invoke with context
         // TODO: Should this actually just get the Node.js request object?

--- a/test/fixtures/cloud-event/index.js
+++ b/test/fixtures/cloud-event/index.js
@@ -1,4 +1,4 @@
-module.exports = function testFunc(data, context) {
+module.exports = function testFunc(context, data) {
   if (context.cloudevent) return { message: data.message };
   else return new Error('No cloud event received');
 };

--- a/test/fixtures/cloud-event/with-response.js
+++ b/test/fixtures/cloud-event/with-response.js
@@ -1,4 +1,4 @@
-module.exports = function testFunc(data, context) {
+module.exports = function testFunc(context, data) {
   if (context.cloudevent) {
     const response = {
       message: data.message

--- a/test/test.js
+++ b/test/test.js
@@ -229,12 +229,12 @@ test('Handles 1.0 CloudEvent Message responses', t => {
   { log: false });
 });
 
-test('Extracts event data as the first parameter to a function', t => {
+test('Extracts event data as the second parameter to a function', t => {
   const data = {
     lunch: "tacos"
   };
 
-  framework(menu => {
+  framework((context, menu) => {
     t.equal(menu.lunch, data.lunch);
     return menu;
   }, server => {
@@ -260,7 +260,7 @@ test('Extracts event data as the first parameter to a function', t => {
 });
 
 test('Successfully handles events with no data', t => {
-  framework((data, context) => {
+  framework((context, data) => {
     t.equal(data, undefined);
     t.true(context.cloudevent instanceof CloudEvent);
     return { status: 'done' }
@@ -279,7 +279,7 @@ test('Successfully handles events with no data', t => {
         t.end();
         server.close();
       });
-  });
+  }, { log: false });
 });
 
 test('Responds with 406 Not Acceptable to unknown cloud event versions', t => {


### PR DESCRIPTION
To make it possible for functions to easily act as both HTTP and CloudEvent
handler it's better to have any potential data as the second parameter.

This change also makes use of a new bit of the cloudevents API to receive an
incoming event, eliminating a transitive dependency on axios.

Fixes: https://github.com/boson-project/faas-js-runtime/issues/62
Fixes: https://github.com/boson-project/faas/issues/194 (when updated in thetemplate)

BREAKING CHANGE

Signed-off-by: Lance Ball <lball@redhat.com>