### PR TITLE
fix: better error handling when network address is already in use

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,34 +20,32 @@ program
 program.parse(process.argv);
 
 function runServer(file) {
-  try {
-    const func = require(extractFullPath(file));
-    runtime(func, server => {
-      ON_DEATH(_ => {
-        server.close();
-        log(chalk.yellow(`
+  const func = require(extractFullPath(file));
+  runtime(func, server => {
+    ON_DEATH(_ => {
+      server.close();
+      log(chalk.yellow(`
 Goodbye!
-        `));
-      });
-
-      log(chalk.blue(`
-The server has started.
-
-You can use curl to POST an event to the endpoint:
-
-curl -X POST -d '{"hello": "world"}' \\
-    -H'Content-type: application/json' \\
-    -H'Ce-id: 1' \\
-    -H'Ce-source: cloud-event-example' \\
-    -H'Ce-type: dev.knative.example' \\
-    -H'Ce-specversion: 1.0' \\
-    http://localhost:8080
-  `));
+      `));
     });
-  } catch (error) {
+  }).then(_ => {
+    log(chalk.blue(`
+    The server has started.
+    
+    You can use curl to POST an event to the endpoint:
+    
+    curl -X POST -d '{"hello": "world"}' \\
+        -H'Content-type: application/json' \\
+        -H'Ce-id: 1' \\
+        -H'Ce-source: cloud-event-example' \\
+        -H'Ce-type: dev.knative.example' \\
+        -H'Ce-specversion: 1.0' \\
+        http://localhost:8080
+      `));    
+  }).catch(error => {
     log(chalk.redBright('Something went wrong'));
     log(chalk.red(error));
-  }
+  });
 }
 
 function extractFullPath(file) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,33 +19,33 @@ program
 
 program.parse(process.argv);
 
-function runServer(file) {
-  const func = require(extractFullPath(file));
-  runtime(func, server => {
+async function runServer(file) {
+  try {
+    const func = require(extractFullPath(file));
+    const server = await runtime(func);
+
     ON_DEATH(_ => {
       server.close();
-      log(chalk.yellow(`
-Goodbye!
-      `));
+      log(chalk.yellow(`Goodbye!`));
     });
-  }).then(_ => {
+
     log(chalk.blue(`
-    The server has started.
-    
-    You can use curl to POST an event to the endpoint:
-    
-    curl -X POST -d '{"hello": "world"}' \\
-        -H'Content-type: application/json' \\
-        -H'Ce-id: 1' \\
-        -H'Ce-source: cloud-event-example' \\
-        -H'Ce-type: dev.knative.example' \\
-        -H'Ce-specversion: 1.0' \\
-        http://localhost:8080
-      `));    
-  }).catch(error => {
+The server has started.
+
+You can use curl to POST an event to the endpoint:
+
+curl -X POST -d '{"hello": "world"}' \\
+    -H'Content-type: application/json' \\
+    -H'Ce-id: 1' \\
+    -H'Ce-source: cloud-event-example' \\
+    -H'Ce-type: dev.knative.example' \\
+    -H'Ce-specversion: 1.0' \\
+    http://localhost:8080`));
+
+  } catch (error) {
     log(chalk.redBright('Something went wrong'));
     log(chalk.red(error));
-  });
+  }
 }
 
 function extractFullPath(file) {


### PR DESCRIPTION
Fixes: https://github.com/boson-project/faas-js-runtime/issues/73

Now, instead of this:
```
> npx faas-js-runtime ./index.js

(node:3724996) UnhandledPromiseRejectionWarning: Error: listen EADDRINUSE: address already in use 0.0.0.0:8080
    at Server.setupListenHandle [as _listen2] (net.js:1317:16)
    at listenInCluster (net.js:1365:12)
    at doListen (net.js:1502:7)
    at processTicksAndRejections (internal/process/task_queues.js:81:21)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:3724996) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:3724996) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

You get this:
```
❯ node cli.js ../test/fixtures/cloud-event/index.js 
Something went wrong
Error: listen EADDRINUSE: address already in use 0.0.0.0:8080
```

Signed-off-by: Lance Ball <lball@redhat.com>