### PR TITLE
fix(cli): Adds the ability to pass logLevel and port from the cli.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,17 +14,20 @@ const program = new Command();
 
 program
   .version(pkg.version)
+  .option('--logLevel', 'change the log level of the function', 'warn')
+  .option('--port', 'change the port the runtime listens on', 8080)
   .arguments('<file>')
   .action(runServer);
 
 program.parse(process.argv);
 
 async function runServer(file) {
+  const programOpts = program.opts();
   try {
     let server;
     let options = {
-      logLevel: process.env.FUNCTION_LOG_LEVEL,
-      port: process.env.LISTEN_PORT
+      logLevel: programOpts.logLevel || process.env.FUNCTION_LOG_LEVEL,
+      port: programOpts.port || process.env.LISTEN_PORT
     };
 
     const filePath = extractFullPath(file);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,12 +22,17 @@ program.parse(process.argv);
 async function runServer(file) {
   try {
     let server;
+    let options = {
+      logLevel: process.env.FUNCTION_LOG_LEVEL,
+      port: process.env.LISTEN_PORT
+    };
+
     const filePath = extractFullPath(file);
     const code = require(filePath);
     if (typeof code === 'function') {
-      server = await start(code);
+      server = await start(code, options);
     } else if (typeof code.handle === 'function') {
-      server = await start(code.handle);
+      server = await start(code.handle, options);
     } else {
       console.error(code);
       throw TypeError(`Cannot find Invokable function 'handle' in ${code}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,8 +14,8 @@ const program = new Command();
 
 program
   .version(pkg.version)
-  .option('--logLevel', 'change the log level of the function', 'warn')
-  .option('--port', 'change the port the runtime listens on', 8080)
+  .option('--logLevel <logLevel>', 'change the log level of the function', 'warn')
+  .option('--port <port>', 'change the port the runtime listens on', 8080)
   .arguments('<file>')
   .action(runServer);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,8 +26,8 @@ async function runServer(file) {
   try {
     let server;
     let options = {
-      logLevel: programOpts.logLevel || process.env.FUNCTION_LOG_LEVEL,
-      port: programOpts.port || process.env.LISTEN_PORT
+      logLevel: programOpts.logLevel || process.env.FUNC_LOG_LEVEL,
+      port: programOpts.port || process.env.FUNC_PORT
     };
 
     const filePath = extractFullPath(file);


### PR DESCRIPTION
This allows a user to specify the FUNCTION_LOG_LEVEL and LISTEN_PORT as environment variables for the cli to pick up.

This makes it a little more consistent with how the Buildpack uses the runtime