### PR TITLE
fix: use cloudevent as second param in test fn

### DIFF
--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -2,17 +2,18 @@ import { expectType } from 'tsd';
 
 import { Server } from 'http';
 import { start, Invokable, Context, LogLevel, InvokerOptions } from '../../index';
+import { CloudEvent } from 'cloudevents';
 
 const fn: Invokable = function(
   context: Context,
-  data: any
+  cloudevent: CloudEvent
 ) {
   return undefined;
-}
+};
 
 const options: InvokerOptions = {
   logLevel: LogLevel.info,
   port: 8080
-}
+};
 
 expectType<Promise<Server>>(start(fn, options));

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -6,7 +6,7 @@ import { CloudEvent } from 'cloudevents';
 
 const fn: Invokable = function(
   context: Context,
-  cloudevent: CloudEvent
+  cloudevent?: CloudEvent
 ) {
   return undefined;
 };


### PR DESCRIPTION
Signed-off-by: Lance Ball <lball@redhat.com>