### PR TITLE
fix: add an explicit scope to function invocation

### DIFF
--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -15,15 +15,16 @@ module.exports = function invoker(func) {
       }
     };
 
+    const scope = Object.freeze({});
     try {
       if (context.cloudevent) {
         // If there is a cloud event, provide the data
         // as the first parameter
-        payload.response = await func(context, context.cloudevent);
+        payload.response = await func.bind(scope)(context, context.cloudevent);
       } else {
         // Invoke with context
         // TODO: Should this actually just get the Node.js request object?
-        payload.response = await func(context);
+        payload.response = await func.bind(scope)(context);
       }
     } catch (err) {
       payload.response = handleError(err, log);

--- a/test/test-scope.js
+++ b/test/test-scope.js
@@ -1,0 +1,85 @@
+
+const { start } = require('..');
+const test = require('tape');
+const request = require('supertest');
+
+function declaredFunction() {
+  return {
+    hasGlobal: this.global !== undefined,
+    isFrozenThis: Object.isFrozen(this)
+  };
+}
+const arrowFunction = () => ({
+    hasGlobal: this.global !== undefined,
+    isFrozenThis: Object.isFrozen(this)
+  });
+
+const errHandler = t => err => {
+  t.error(err);
+  t.end();
+};
+
+const tests = {
+  arrowFunctionTests: [
+    {
+      test: 'Does not have a global object',
+      func: checkHasGlobal,
+      expect: false
+    },
+    {
+      test: 'Has unfrozen this',
+      func: checkIsFrozen,
+      expect: false
+    }
+  ],
+  declaredFunctionTests: [
+    {
+      test: 'Does not have a global object',
+      func: checkHasGlobal,
+      expect: false
+    },
+    {
+      test: 'Has frozen this',
+      func: checkIsFrozen,
+      expect: true
+    }
+  ]
+};
+
+for (const tt of tests.declaredFunctionTests) {
+  test(tt.test, t => {
+    start(declaredFunction)
+      .then(s => tt.func(s, t, tt.expect), errHandler(t));
+  });
+}
+
+for (const tt of tests.arrowFunctionTests) {
+  test(tt.test, t => {
+    start(arrowFunction)
+      .then(s => tt.func(s, t, tt.expect), errHandler(t));
+  });
+}
+
+function checkHasGlobal(server, t, expected) {
+  request(server)
+  .get('/')
+  .expect(200)
+  .end((err, res) => {
+    t.error(err, 'No error');
+    t.equal(res.body.hasGlobal, expected);
+    t.end();
+    server.close();
+  });
+}
+
+function checkIsFrozen(server, t, expected) {
+  request(server)
+  .get('/')
+  .expect(200)
+  .end((err, res) => {
+    t.error(err, 'No error');
+    t.equal(res.body.isFrozenThis, expected);
+    t.end();
+    server.close();
+  });
+}


### PR DESCRIPTION
Prevents functions from having access to the global scope during
function invocation. Currently the scope is a frozen, empty object.

Fixes: https://github.com/boson-project/faas-js-runtime/issues/117

Signed-off-by: Lance Ball <lball@redhat.com>