### PR TITLE
fix(types): use CloudEvent<any> for typed events

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -6,11 +6,11 @@ import { CloudEvent } from 'cloudevents';
  * CloudEventFunction describes the function signature for a function that accepts CloudEvents.
  */
  export interface CloudEventFunction {
-  (context: Context, event: CloudEvent): CloudEventFunctionReturn;
+  (context: Context, event: CloudEvent<any>): CloudEventFunctionReturn;
 }
 
 // CloudEventFunctionReturn is the return type for a CloudEventFunction.
-export type CloudEventFunctionReturn = Promise<CloudEvent> | CloudEvent | HTTPFunctionReturn;
+export type CloudEventFunctionReturn = Promise<CloudEvent<any>> | CloudEvent<any> | HTTPFunctionReturn;
 
 /**
  * HTTPFunction describes the function signature for a function that handles
@@ -50,7 +50,7 @@ export interface Context {
     httpVersion: string;
     httpVersionMajor: number;
     httpVersionMinor: number;
-    cloudevent: CloudEvent;
+    cloudevent: CloudEvent<any>;
     cloudEventResponse(data: string|object): CloudEventResponse;
 }
 

--- a/test/types/context.test-d.ts
+++ b/test/types/context.test-d.ts
@@ -18,7 +18,7 @@ expectType<string>(context.method);
 expectType<string>(context.httpVersion);
 expectType<number>(context.httpVersionMajor);
 expectType<number>(context.httpVersionMinor);
-expectType<CloudEvent>(context.cloudevent);
+expectType<CloudEvent<any>>(context.cloudevent);
 expectAssignable<Record<string, any>|string|undefined>(context.body);
 
 // CloudEventResponse


### PR DESCRIPTION
Fixes type incompatibility with typed CloudEvent functions.

/kind fix

Signed-off-by: Lance Ball <lball@redhat.com>